### PR TITLE
Add `initialData` function

### DIFF
--- a/Container.html
+++ b/Container.html
@@ -5,10 +5,11 @@ import { Tracker } from 'meteor/tracker';
 
 export default {
   oncreate() {
-    const { data, oncreate } = this._options;
+    const { initialData, data, oncreate } = this._options;
 
     this._instance = new this._component({
-      target: this.refs._container
+      target: this.refs._container,
+      data: initialData && initialData.call()
     });
 
     // Create an empty context object that will be passed as `this` to each

--- a/README.md
+++ b/README.md
@@ -16,8 +16,13 @@ withTracker(component, options)
 ```
 
 The `options` object can contain the functions listed below.
-Each of these functions receives the rendered instance of the wrapped component as argument and an initially empty context object as `this`.
+Except for `initialData`, each of these functions receives the rendered instance of the wrapped component as argument and an initially empty context object as `this`.
 You can use this context object to store container state, e.g., live query handles and timeout identifiers.
+
+**`initialData()`** (optional)
+
+Called before the wrapped component is instantiated.
+Must return an object with the initial data.
 
 **`data(component)`** (required)
 


### PR DESCRIPTION
The `initialData` function can provide data at the time the wrapped component is instantiated (to silence [dev mode warnings](https://github.com/meteor-svelte/meteor-svelte/pull/12#issue-248109130)), for example (from the `tracker-example` repo):

```js
export default withTracker(PersonComponent, {
  initialData() {
    return {
      person: { name: '' }
    };
  },

  data(component) {
    component.set({
      person: Persons.findOne()
    });
  },

  ...
});
```